### PR TITLE
Proper `JValue` handling in partials parameters

### DIFF
--- a/source/Handlebars.Extension/Handlebars.Extension.csproj
+++ b/source/Handlebars.Extension/Handlebars.Extension.csproj
@@ -55,7 +55,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Handlebars.Net" Version="2.0.3" />
+    <PackageReference Include="Handlebars.Net" Version="2.0.4" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
   

--- a/source/Handlebars.Extension/JValueDescriptorProvider.cs
+++ b/source/Handlebars.Extension/JValueDescriptorProvider.cs
@@ -1,0 +1,38 @@
+using System;
+using HandlebarsDotNet.ObjectDescriptors;
+using HandlebarsDotNet.PathStructure;
+using Newtonsoft.Json.Linq;
+
+namespace HandlebarsDotNet.Extension.NewtonsoftJson
+{
+    internal class JValueDescriptorProvider : IObjectDescriptorProvider
+    {
+        private static readonly Type Type = typeof(JValue);
+        private static readonly JValueMemberAccessor MemberAccessor = new JValueMemberAccessor();
+        
+        public bool TryGetDescriptor(Type type, out ObjectDescriptor value)
+        {
+            if (Type != type)
+            {
+                value = ObjectDescriptor.Empty;
+                return false;
+            }
+            
+            value = new ObjectDescriptor(
+                typeof(JObject), 
+                MemberAccessor,
+                (d, o) =>
+                {
+                    var jValue = (o as JValue)?.Value;
+                    if (jValue == null || !ObjectDescriptorFactory.Current.TryGetDescriptor(jValue.GetType(), out var localDescriptor))
+                        return new ChainSegment[0];
+                    
+                    return new ObjectAccessor(jValue, localDescriptor).Properties;
+                },
+                self => new JValueIterator()
+            );
+            
+            return true;
+        }
+    }
+}

--- a/source/Handlebars.Extension/JValueIterator.cs
+++ b/source/Handlebars.Extension/JValueIterator.cs
@@ -1,0 +1,26 @@
+using System;
+using HandlebarsDotNet.Compiler;
+using HandlebarsDotNet.Iterators;
+using HandlebarsDotNet.ObjectDescriptors;
+using HandlebarsDotNet.PathStructure;
+using Newtonsoft.Json.Linq;
+
+namespace HandlebarsDotNet.Extension.NewtonsoftJson
+{
+    internal class JValueIterator : IIterator
+    {
+        public void Iterate(
+            in EncodedTextWriter writer, 
+            BindingContext context, 
+            ChainSegment[] blockParamsVariables, 
+            object input,
+            TemplateDelegate template, 
+            TemplateDelegate ifEmpty)
+        {
+            var value = (input as JValue)?.Value;
+            if(value == null || !ObjectDescriptorFactory.Current.TryGetDescriptor(value.GetType(), out var descriptor)) return;
+            
+            descriptor.Iterator.Iterate(writer, context, blockParamsVariables, value, template, ifEmpty);
+        }
+    }
+}

--- a/source/Handlebars.Extension/JValueMemberAccessor.cs
+++ b/source/Handlebars.Extension/JValueMemberAccessor.cs
@@ -1,0 +1,22 @@
+using HandlebarsDotNet.MemberAccessors;
+using HandlebarsDotNet.ObjectDescriptors;
+using HandlebarsDotNet.PathStructure;
+using Newtonsoft.Json.Linq;
+
+namespace HandlebarsDotNet.Extension.NewtonsoftJson
+{
+    internal class JValueMemberAccessor : IMemberAccessor
+    {
+        public bool TryGetValue(object instance, ChainSegment memberName, out object? value)
+        {
+            var obj = (instance as JValue)?.Value;
+            if (obj == null || !ObjectDescriptorFactory.Current.TryGetDescriptor(obj.GetType(), out var descriptor))
+            {
+                value = null;
+                return false;
+            }
+
+            return descriptor.MemberAccessor.TryGetValue(obj, memberName, out value);
+        }
+    }
+}

--- a/source/Handlebars.Extension/JsonFeatureExtensions.cs
+++ b/source/Handlebars.Extension/JsonFeatureExtensions.cs
@@ -27,14 +27,13 @@ namespace HandlebarsDotNet.Extension.NewtonsoftJson
     
     internal class JsonFeature : IFeature, IFeatureFactory
     {
-        private static readonly JObjectDescriptorProvider JObjectDescriptorProvider = new JObjectDescriptorProvider();
-
         public void OnCompiling(ICompiledHandlebarsConfiguration configuration)
         {
             var providers = configuration.ObjectDescriptorProviders;
             var objectDescriptorProvider = providers.OfType<ObjectDescriptorProvider>().Single();
             providers.Add(new JArrayDescriptorProvider(objectDescriptorProvider));
-            providers.Add(JObjectDescriptorProvider);
+            providers.Add(new JObjectDescriptorProvider());
+            providers.Add(new JValueDescriptorProvider());
             
             configuration.FormatterProviders.Add(new JFormatterProvider());
         }


### PR DESCRIPTION
What's inside:
- dedicated types to handle `JValue` as partial parameter
 
Issues:
- closes https://github.com/Handlebars-Net/Handlebars.Net/issues/428