### PR TITLE
`JObjectMemberAccessor` should respect `[]`

### DIFF
--- a/source/Handlebars.Extension.Test/IssueTests.cs
+++ b/source/Handlebars.Extension.Test/IssueTests.cs
@@ -89,5 +89,23 @@ namespace HandlebarsDotNet.Extension.Test
             
            Assert.Equal(actual, string.Join("", expected));
         }
+        
+        // issue: https://github.com/Handlebars-Net/Handlebars.Net.Extension.NewtonsoftJson/issues/5
+        [Fact]
+        public void EscapedPathWithDots()
+        {
+            var handlebars = Handlebars.Create();
+            var template = handlebars.Compile("{{ withDots.[one.two.three] }}");
+
+            var actual = template(new JObject
+            {
+                ["withDots"] = new JObject
+                {
+                    ["one.two.three"] = 42
+                }
+            });
+    
+            Assert.Equal("42", actual);
+        }
     }
 }

--- a/source/Handlebars.Extension/JObjectMemberAccessor.cs
+++ b/source/Handlebars.Extension/JObjectMemberAccessor.cs
@@ -10,7 +10,7 @@ namespace HandlebarsDotNet.Extension.NewtonsoftJson
         public bool TryGetValue(object instance, ChainSegment memberName, out object? value)
         {
             var jObject = (JObject) instance;
-            if (jObject.TryGetValue(memberName, StringComparison.OrdinalIgnoreCase, out var token))
+            if (jObject.TryGetValue(memberName.TrimmedValue, StringComparison.OrdinalIgnoreCase, out var token))
             {
                 value = token is JValue jValue 
                     ? jValue.Value 


### PR DESCRIPTION
Closes #6 